### PR TITLE
Support reject (for example wrong hostname)

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -43,6 +43,7 @@ export class Request {
     this._formData = new FormData();
     this._promise = new Promise((resolve, reject) => {
       this._xhr.onload = buildResponseHandler(this._xhr, resolve, reject);
+      this._xhr.onerror = buildResponseHandler(this._xhr, resolve, reject);
     });
     Object.keys(attrs).forEach((k) => this.set(k, attrs[k]));
     Object.keys(headers).forEach((k) => this.header(k, headers[k]));
@@ -70,8 +71,8 @@ export class Request {
     return this;
   }
 
-  then(fn) {
-    this._promise = this._promise.then(fn);
+  then(fn, reject) {
+    this._promise = this._promise.then(fn, reject);
     return this;
   }
 


### PR DESCRIPTION
If your bucket name is wrong (for example it contains some ::: ) then you'll end up with a wrong hostname. Then the Request promise should return a reject but the current Request only return response.
