### PR TITLE
allow custom region url

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Arguments:
   * `accessKey` **required** - Your S3 `AWSAccessKeyId`
   * `secretKey` **required** - Your S3 `AWSSecretKey`
   * `successActionStatus` - HTTP response status if successful, defaults to 201.
+  * `awsUrl` - S3 Aws Url (http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) default: s3.amazonaws.com
 
 Returns an object that behaves like a promise. It also has a `progress` method on it which accepts a callback and will invoke the callback with the upload progress.
 

--- a/src/RNS3.js
+++ b/src/RNS3.js
@@ -32,7 +32,7 @@ export class RNS3 {
       contentType: file.type
     });
 
-    let url = `https://${ options.bucket }.s3.amazonaws.com`;
+    let awsUrl = `https://${ options.bucket }.${options.awsUrl || 's3.amazonaws.com'}`;
     let method = "POST";
     let policy = S3Policy.generate(options);
 


### PR DESCRIPTION
I can't use the package without changing it to `url: 's3-eu-west-1.amazonaws.com',` so it will be great if this can be merged