### PR TITLE
Allow for time sway

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Arguments:
   * `secretKey` **required** - Your S3 `AWSSecretKey`
   * `successActionStatus` - HTTP response status if successful, defaults to 201
   * `awsUrl` - [AWS S3 url](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). Defaults to `s3.amazonaws.com`
+  * `timeDelta` - Devices time offset from world clock in milliseconds, defaults to 0
 
 Returns an object that wraps an `XMLHttpRequest` instance and behaves like a promise, with the following additional methods:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-aws3",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "description": "Pure JavaScript react native library for uploading to AWS S3",
   "author": {
     "name": "Ben Reinhart"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-aws3",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pure JavaScript react native library for uploading to AWS S3",
   "author": {
     "name": "Ben Reinhart"

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -53,7 +53,7 @@ const getDate = (options) => {
  */
 const getExpirationDate = () => {
   return new Date(
-    (new Date).getTime() + FIVE_MINUTES
+    (new Date).getTime() + FIVE_MINUTES + (Math.abs(options.timeDelta) || 0)
   ).toISOString();
 }
 

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -34,9 +34,9 @@ export class S3Policy {
   }
 }
 
-const getDate = (options) => {
+const getDate = (timeDelta) => {
   let date = new Date(
-    (new Date).getTime() + (options.timeDelta || 0)
+    (new Date).getTime() + timeDelta
   );
   let yymmdd = date.toISOString().slice(0, 10).replace(/-/g, "");
   let amzDate = yymmdd + "T000000Z";
@@ -51,15 +51,16 @@ const getDate = (options) => {
  *
  *     2016-03-24T20:43:47.314Z
  */
-const getExpirationDate = () => {
+const getExpirationDate = (timeDelta) => {
   return new Date(
-    (new Date).getTime() + FIVE_MINUTES + (Math.abs(options.timeDelta) || 0)
+    (new Date).getTime() + FIVE_MINUTES + Math.abs(timeDelta)
   ).toISOString();
 }
 
 const getPolicyParams = (options) => {
-  let date = getDate(options);
-  let expiration = getExpirationDate();
+  let timeDelta = (options.timeDelta || 0);
+  let date = getDate(timeDelta);
+  let expiration = getExpirationDate(timeDelta);
 
   return {
     acl: options.acl || AWS_ACL,

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -34,8 +34,10 @@ export class S3Policy {
   }
 }
 
-const getDate = () => {
-  let date = new Date();
+const getDate = (options) => {
+  let date = new Date(
+    (new Date).getTime() + (options.timeDelta || 0)
+  );
   let yymmdd = date.toISOString().slice(0, 10).replace(/-/g, "");
   let amzDate = yymmdd + "T000000Z";
   return { yymmdd: yymmdd, amzDate: amzDate }
@@ -56,7 +58,7 @@ const getExpirationDate = () => {
 }
 
 const getPolicyParams = (options) => {
-  let date = getDate();
+  let date = getDate(options);
   let expiration = getExpirationDate();
 
   return {

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -35,9 +35,7 @@ export class S3Policy {
 }
 
 const getDate = () => {
-  let date = new Date(
-    (new Date).getTime()
-  );
+  let date = new Date();
   let yymmdd = date.toISOString().slice(0, 10).replace(/-/g, "");
   let amzDate = yymmdd + "T000000Z";
   return { yymmdd: yymmdd, amzDate: amzDate }

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -34,9 +34,9 @@ export class S3Policy {
   }
 }
 
-const getDate = (timeDelta) => {
+const getDate = () => {
   let date = new Date(
-    (new Date).getTime() + timeDelta
+    (new Date).getTime()
   );
   let yymmdd = date.toISOString().slice(0, 10).replace(/-/g, "");
   let amzDate = yymmdd + "T000000Z";
@@ -53,13 +53,13 @@ const getDate = (timeDelta) => {
  */
 const getExpirationDate = (timeDelta) => {
   return new Date(
-    (new Date).getTime() + FIVE_MINUTES + Math.abs(timeDelta)
+    (new Date).getTime() + FIVE_MINUTES + (-1 * timeDelta)
   ).toISOString();
 }
 
 const getPolicyParams = (options) => {
   let timeDelta = (options.timeDelta || 0);
-  let date = getDate(timeDelta);
+  let date = getDate();
   let expiration = getExpirationDate(timeDelta);
 
   return {

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -53,7 +53,7 @@ const getDate = () => {
  */
 const getExpirationDate = (timeDelta) => {
   return new Date(
-    (new Date).getTime() + FIVE_MINUTES + (-1 * timeDelta)
+    (new Date).getTime() + FIVE_MINUTES - timeDelta
   ).toISOString();
 }
 


### PR DESCRIPTION
Some users for various reasons may have their device's time set to a different time than the world clocks time. Normally this would get blocked by AWS unless you specify the offset in the policy expiration and `x-aws-date` header. This PR allows you to pass the `timeDelta` option to allow device time to sway.