### PR TITLE
Remove https from bucket url to fix issue HTTP load failed (kCFStreamErrorDomainSSL, -9843 on iOS devices.

### DIFF
--- a/src/RNS3.js
+++ b/src/RNS3.js
@@ -38,7 +38,7 @@ export class RNS3 {
       contentType: file.type
     }
 
-    const url = `https://${options.bucket}.${options.awsUrl || AWS_DEFAULT_S3_HOST}`
+    const url = `http://${options.bucket}.${options.awsUrl || AWS_DEFAULT_S3_HOST}`
     const method = "POST"
     const policy = S3Policy.generate(options)
 


### PR DESCRIPTION
Hello,

This will fix the issue with the 'NSURLSession/NSURLConnection HTTP load failed (kCFStreamErrorDomainSSL, -9843)' when trying to upload an image/video to your amazon bucket on iOS devices.

You also need to add this into your info.plist on NSAppTransportSecurity

```
<key>amazonaws.com</key>
   <dict>
     <key>NSExceptionAllowsInsecureHTTPLoads</key>
      <true/>
   </dict>
```
