### PR TITLE
Allow s3 urls to be set as path instead of subdomain + automatic region URL

### DIFF
--- a/src/RNS3.js
+++ b/src/RNS3.js
@@ -5,8 +5,6 @@
 import { Request } from './Request'
 import { S3Policy } from './S3Policy'
 
-const AWS_DEFAULT_S3_HOST = 's3.amazonaws.com'
-
 const EXPECTED_RESPONSE_KEY_VALUE_RE = {
   key: /<Key>(.*)<\/Key>/,
   etag: /<ETag>"?([^"]*)"?<\/ETag>/,
@@ -30,6 +28,14 @@ const setBodyAsParsedXML = (response) =>
   })
 
 export class RNS3 {
+  static getAwsUrl(options) {
+    if(options.awsUrl) {
+      return options.awsUrl;
+    }
+
+    return `s3${options.region ? `-${options.region}` : ''}.amazonaws.com`;
+  }
+
   static put(file, options) {
     options = {
       ...options,
@@ -38,7 +44,9 @@ export class RNS3 {
       contentType: file.type
     }
 
-    const url = `https://${options.bucket}.${options.awsUrl || AWS_DEFAULT_S3_HOST}`
+    const url = options.urlAsPath ?
+      `https://${RNS3.getAwsUrl(options)}/${options.bucket}` :
+      `https://${options.bucket}.${RNS3.getAwsUrl(options)}`
     const method = "POST"
     const policy = S3Policy.generate(options)
 


### PR DESCRIPTION
When using a bucket name that looks like a domain name, the TLS security hits and blocks the request, this can be fixed when using react-native alone by lowering some security checks, but on an expo project, there's no fix. This will add an option: `urlAsPath` which which change s3 upload url from `my.bucket.com.s3.amazonaws.com` to `s3.amazonaws.com/my.bucket.com`.

In addition, I made the region url to be generated automatically.