### PR TITLE
Request host URL updated, in case of bucket name as `com.xyz.app`.

### DIFF
--- a/src/RNS3.js
+++ b/src/RNS3.js
@@ -38,7 +38,7 @@ export class RNS3 {
       contentType: file.type
     }
 
-    const url = `https://${options.bucket}.${options.awsUrl || AWS_DEFAULT_S3_HOST}`
+    const url = `https://${options.awsUrl || AWS_DEFAULT_S3_HOST}/${options.bucket}`
     const method = "POST"
     const policy = S3Policy.generate(options)
 


### PR DESCRIPTION
Issue:
The certificate for this server is invalid. You might be connecting to a server that is pretending to be “com.xyz.app.s3.amazonaws.com” which could put your confidential information at risk.