### PR TITLE
add sessionToken option to support temprary security credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Arguments:
   * `region` **required** - The region of your S3 bucket
   * `accessKey` **required** - Your S3 `AWSAccessKeyId`
   * `secretKey` **required** - Your S3 `AWSSecretKey`
+  * `sessionToken` - Your S3 `SessionToken` if you use temprary security credentials
   * `successActionStatus` - HTTP response status if successful, defaults to 201
   * `awsUrl` - [AWS S3 url](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). Defaults to `s3.amazonaws.com`
   * `timeDelta` - Devices time offset from world clock in milliseconds, defaults to 0

--- a/lib/DateUtils.js
+++ b/lib/DateUtils.js
@@ -1,0 +1,30 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _formatters;
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * DateUtils
+ */
+
+var YYYYMMDD = 'yyyymmdd';
+var ISO8601 = 'iso8601';
+var AMZ_ISO8601 = 'amz-iso8601';
+
+var formatters = (_formatters = {}, _defineProperty(_formatters, ISO8601, function (date) {
+  return date.toISOString();
+}), _defineProperty(_formatters, YYYYMMDD, function (date) {
+  return formatters[ISO8601](date).slice(0, 10).replace(/-/g, "");
+}), _defineProperty(_formatters, AMZ_ISO8601, function (date) {
+  return formatters[YYYYMMDD](date) + 'T000000Z';
+}), _formatters);
+
+var dateToString = exports.dateToString = function dateToString(date) {
+  var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : ISO8601;
+  return formatters[format](date);
+};

--- a/lib/RNS3.js
+++ b/lib/RNS3.js
@@ -1,0 +1,79 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.RNS3 = undefined;
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }(); /**
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          * RNS3
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          */
+
+var _Request = require('./Request');
+
+var _S3Policy = require('./S3Policy');
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var AWS_DEFAULT_S3_HOST = 's3.amazonaws.com';
+
+var EXPECTED_RESPONSE_KEY_VALUE_RE = {
+  key: /<Key>(.*)<\/Key>/,
+  etag: /<ETag>"?([^"]*)"?<\/ETag>/,
+  bucket: /<Bucket>(.*)<\/Bucket>/,
+  location: /<Location>(.*)<\/Location>/
+};
+
+var entries = function entries(o) {
+  return Object.keys(o).map(function (k) {
+    return [k, o[k]];
+  });
+};
+
+var extractResponseValues = function extractResponseValues(responseText) {
+  return entries(EXPECTED_RESPONSE_KEY_VALUE_RE).reduce(function (result, _ref) {
+    var _ref2 = _slicedToArray(_ref, 2),
+        key = _ref2[0],
+        regex = _ref2[1];
+
+    var match = responseText.match(regex);
+    return _extends({}, result, _defineProperty({}, key, match && match[1]));
+  }, {});
+};
+
+var setBodyAsParsedXML = function setBodyAsParsedXML(response) {
+  return _extends({}, response, {
+    body: { postResponse: response.text == null ? null : extractResponseValues(response.text) }
+  });
+};
+
+var RNS3 = exports.RNS3 = function () {
+  function RNS3() {
+    _classCallCheck(this, RNS3);
+  }
+
+  _createClass(RNS3, null, [{
+    key: 'put',
+    value: function put(file, options) {
+      options = _extends({}, options, {
+        key: (options.keyPrefix || '') + file.name,
+        date: new Date(),
+        contentType: file.type
+      });
+
+      var url = 'https://' + options.bucket + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST);
+      var method = "POST";
+      var policy = _S3Policy.S3Policy.generate(options);
+
+      return _Request.Request.create(url, method, policy).set("file", file).send().then(setBodyAsParsedXML);
+    }
+  }]);
+
+  return RNS3;
+}();

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -1,0 +1,149 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ * Request
+ */
+
+var isBlank = function isBlank(string) {
+  return null == string || !/\S/.test(string);
+};
+
+var notBlank = function notBlank(string) {
+  return !isBlank(string);
+};
+
+var parseHeaders = function parseHeaders(xhr) {
+  return (xhr.getAllResponseHeaders() || '').split(/\r?\n/).filter(notBlank).reduce(function (headers, headerString) {
+    var header = headerString.split(":")[0];
+    headers[header] = xhr.getResponseHeader(header);
+    return headers;
+  }, {});
+};
+
+var buildResponseObject = function buildResponseObject(xhr) {
+  var headers = {};
+  try {
+    headers = parseHeaders(xhr);
+  } catch (e) {};
+  return {
+    status: xhr.status,
+    text: xhr.responseText,
+    headers: headers
+  };
+};
+
+var buildResponseHandler = function buildResponseHandler(xhr, resolve, reject) {
+  return function () {
+    var fn = xhr.status === 0 ? reject : resolve;
+    fn(buildResponseObject(xhr));
+  };
+};
+
+var decorateProgressFn = function decorateProgressFn(fn) {
+  return function (e) {
+    e.percent = e.loaded / e.total;
+    return fn(e);
+  };
+};
+
+var Request = exports.Request = function () {
+  _createClass(Request, null, [{
+    key: "create",
+    value: function create() {
+      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      return new (Function.prototype.bind.apply(this, [null].concat(args)))();
+    }
+  }]);
+
+  function Request(url, method) {
+    var _this = this;
+
+    var attrs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var headers = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+    _classCallCheck(this, Request);
+
+    this._xhr = new Request.XMLHttpRequest();
+    this._formData = new Request.FormData();
+
+    this._xhr.open(method, url);
+
+    this._promise = new Promise(function (resolve, reject) {
+      _this._xhr.onload = buildResponseHandler(_this._xhr, resolve, reject);
+      _this._xhr.onerror = buildResponseHandler(_this._xhr, resolve, reject);
+    });
+
+    Object.keys(attrs).forEach(function (k) {
+      return _this.set(k, attrs[k]);
+    });
+    Object.keys(headers).forEach(function (k) {
+      return _this.header(k, headers[k]);
+    });
+  }
+
+  _createClass(Request, [{
+    key: "header",
+    value: function header(key, value) {
+      this._xhr.setRequestHeader(key, value);
+      return this;
+    }
+  }, {
+    key: "set",
+    value: function set(key, value) {
+      this._formData.append(key, value);
+      return this;
+    }
+  }, {
+    key: "send",
+    value: function send() {
+      this._xhr.send(this._formData);
+      return this;
+    }
+  }, {
+    key: "abort",
+    value: function abort() {
+      this._xhr.abort();
+      return this;
+    }
+  }, {
+    key: "progress",
+    value: function progress(fn) {
+      if (this._xhr.upload) {
+        this._xhr.upload.onprogress = decorateProgressFn(fn);
+      }
+      return this;
+    }
+  }, {
+    key: "then",
+    value: function then() {
+      var _promise;
+
+      this._promise = (_promise = this._promise).then.apply(_promise, arguments);
+      return this;
+    }
+  }, {
+    key: "catch",
+    value: function _catch() {
+      var _promise2;
+
+      this._promise = (_promise2 = this._promise).catch.apply(_promise2, arguments);
+      return this;
+    }
+  }]);
+
+  return Request;
+}();
+
+Request.FormData = FormData;
+Request.XMLHttpRequest = XMLHttpRequest;

--- a/lib/S3Policy.js
+++ b/lib/S3Policy.js
@@ -1,0 +1,121 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ * S3Policy
+ */
+
+var CryptoJS = require('crypto-js');
+var Buffer = global.Buffer || require('buffer').Buffer;
+
+var _require = require('./DateUtils'),
+    dateToString = _require.dateToString;
+
+var FIVE_MINUTES = 5 * (60 * 1000);
+
+var AWS_ACL = "public-read";
+var AWS_SERVICE_NAME = "s3";
+var AWS_REQUEST_POLICY_VERSION = "aws4_request";
+var AWS_ALGORITHM = "AWS4-HMAC-SHA256";
+
+var DEFAULT_SUCCESS_ACTION_STATUS = "201";
+
+var assert = function assert(object, message) {
+  if (null == object) throw new Error(message);
+};
+
+var S3Policy = exports.S3Policy = function () {
+  function S3Policy() {
+    _classCallCheck(this, S3Policy);
+  }
+
+  _createClass(S3Policy, null, [{
+    key: 'generate',
+    value: function generate(options) {
+      options || (options = {});
+
+      assert(options.key, "Must provide `key` option with the object key");
+      assert(options.bucket, "Must provide `bucket` option with your AWS bucket name");
+      assert(options.contentType, "Must provide `contentType` option with the object content type");
+      assert(options.region, "Must provide `region` option with your AWS region");
+      assert(options.date, "Must provide `date` option with the current date");
+      assert(options.accessKey, "Must provide `accessKey` option with your AWSAccessKeyId");
+      assert(options.secretKey, "Must provide `secretKey` option with your AWSSecretKey");
+
+      var date = options.date;
+      var timeDelta = options.timeDelta || 0;
+      var policyExpiresIn = FIVE_MINUTES - timeDelta;
+      var expirationDate = new Date(date.getTime() + policyExpiresIn);
+
+      var policyParams = _extends({}, options, {
+        acl: options.acl || AWS_ACL,
+        algorithm: AWS_ALGORITHM,
+        amzDate: dateToString(date, 'amz-iso8601'),
+        yyyymmddDate: dateToString(date, 'yyyymmdd'),
+        expirationDate: dateToString(expirationDate, 'iso8601'),
+        successActionStatus: String(options.successActionStatus || DEFAULT_SUCCESS_ACTION_STATUS)
+      });
+
+      policyParams.credential = [policyParams.accessKey, policyParams.yyyymmddDate, policyParams.region, AWS_SERVICE_NAME, AWS_REQUEST_POLICY_VERSION].join('/');
+
+      var policy = formatPolicyForEncoding(policyParams);
+      var base64EncodedPolicy = getEncodedPolicy(policy);
+      var signature = getSignature(base64EncodedPolicy, policyParams);
+
+      return formatPolicyForRequestBody(base64EncodedPolicy, signature, policyParams);
+    }
+  }]);
+
+  return S3Policy;
+}();
+
+var formatPolicyForRequestBody = function formatPolicyForRequestBody(base64EncodedPolicy, signature, options) {
+  var body = {
+    "key": options.key,
+    "acl": options.acl,
+    "success_action_status": options.successActionStatus,
+    "Content-Type": options.contentType,
+    "X-Amz-Credential": options.credential,
+    "X-Amz-Algorithm": options.algorithm,
+    "X-Amz-Date": options.amzDate,
+    "Policy": base64EncodedPolicy,
+    "X-Amz-Signature": signature
+  };
+  if (options.sessionToken) body["x-amz-security-token"] = options.sessionToken;
+  return body;
+};
+
+var formatPolicyForEncoding = function formatPolicyForEncoding(policy) {
+  var formattedPolicy = {
+    "expiration": policy.expirationDate,
+    "conditions": [{ "bucket": policy.bucket }, { "key": policy.key }, { "acl": policy.acl }, { "success_action_status": policy.successActionStatus }, { "Content-Type": policy.contentType }, { "x-amz-credential": policy.credential }, { "x-amz-algorithm": policy.algorithm }, { "x-amz-date": policy.amzDate }]
+  };
+  if (policy.sessionToken) formattedPolicy.conditions.push({ "x-amz-security-token": policy.sessionToken });
+  return formattedPolicy;
+};
+
+var getEncodedPolicy = function getEncodedPolicy(policy) {
+  return Buffer.from(JSON.stringify(policy), "utf-8").toString("base64");
+};
+
+var getSignature = function getSignature(base64EncodedPolicy, options) {
+  return CryptoJS.HmacSHA256(base64EncodedPolicy, getSignatureKey(options)).toString(CryptoJS.enc.Hex);
+};
+
+var getSignatureKey = function getSignatureKey(options) {
+  var kDate = CryptoJS.HmacSHA256(options.yyyymmddDate, "AWS4" + options.secretKey);
+  var kRegion = CryptoJS.HmacSHA256(options.region, kDate);
+  var kService = CryptoJS.HmacSHA256(AWS_SERVICE_NAME, kRegion);
+  var kSigning = CryptoJS.HmacSHA256(AWS_REQUEST_POLICY_VERSION, kService);
+
+  return kSigning;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-aws3",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Pure JavaScript react native library for uploading to AWS S3",
   "author": {
     "name": "Ben Reinhart"

--- a/src/S3Policy.js
+++ b/src/S3Policy.js
@@ -63,7 +63,7 @@ export class S3Policy {
 }
 
 const formatPolicyForRequestBody = (base64EncodedPolicy, signature, options) => {
-  return {
+  var body = {
     "key": options.key,
     "acl": options.acl,
     "success_action_status": options.successActionStatus,
@@ -72,12 +72,15 @@ const formatPolicyForRequestBody = (base64EncodedPolicy, signature, options) => 
     "X-Amz-Algorithm": options.algorithm,
     "X-Amz-Date": options.amzDate,
     "Policy": base64EncodedPolicy,
-    "X-Amz-Signature": signature,
+    "X-Amz-Signature": signature
   }
+  if (options.sessionToken)
+    body["x-amz-security-token"] = options.sessionToken
+  return body
 }
 
 const formatPolicyForEncoding = (policy) => {
-  return {
+  var formattedPolicy = {
     "expiration": policy.expirationDate,
     "conditions": [
        {"bucket": policy.bucket},
@@ -90,6 +93,9 @@ const formatPolicyForEncoding = (policy) => {
        {"x-amz-date": policy.amzDate}
     ]
   }
+  if (policy.sessionToken)
+    formattedPolicy.conditions.push({"x-amz-security-token": policy.sessionToken})
+  return formattedPolicy
 }
 
 const getEncodedPolicy = (policy) => {


### PR DESCRIPTION
This pull request is to support temporary security credentials.

To upload a file with temporary security credentials, you have to add `x-amz-security-token` header, as described in [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#UsingTemporarySecurityCredentials).
You can do this by adding `sessionToken` in `options` argument.